### PR TITLE
centralize error messages and loading state across LoginForm and GoogleAuth

### DIFF
--- a/src/components/GoogleAuth/GoogleAuth.js
+++ b/src/components/GoogleAuth/GoogleAuth.js
@@ -91,7 +91,7 @@ const GoogleAuth = ({ setMsg, setSuccess, setLoading }) => {
   };
 
   return (
-    <div className="w-full flex flex-col items-center justify-center space-y-0">
+    <div className="flex flex-col items-center justify-center space-y-2 w-[17.5rem] md:w-[18rem] lg:w-[25rem]">
       <Button
         text={translations["logIn.signin-google"]}
         onClick={() => login()}
@@ -99,7 +99,7 @@ const GoogleAuth = ({ setMsg, setSuccess, setLoading }) => {
         icon="/icons/google-darkred.svg"
         data-testid="login-google-button"
         aria-label="Google Sign In"
-        className="space-y-1"
+        className="w-full"
       />
     </div>
   );

--- a/src/components/LogIn/LogInScreen.js
+++ b/src/components/LogIn/LogInScreen.js
@@ -6,7 +6,7 @@ const LoginScreen = () => {
   // const { translations } = useLanguage();
 
   return (
-    <div className="flex flex-col min-h-screen bg-primary-light sm:bg-dots-lg sm:bg-dots-size-lg bg-dots-sm bg-dots-size-sm">
+    <div className="flex flex-col min-h-screen bg-primary-light sm:bg-dots-lg sm:bg-dots-size-lg bg-dots-sm bg-dots-size-sm justify-center">
       <div className="flex justify-center items-center overflow-hidden md:mt-[7.5rem] px-4 mx-8 md:mx-8 h-[38rem] md:h-full md:min-h-screen items-stretch">
         <section className="flex flex-col pt-4 items-center rounded-3xl md:rounded-l-xl md:rounded-r-none justify-center bg-white flex-1 max-w-[35.781rem] max-h-[34.375rem] md:h-auto p-4">
           <LoginForm />

--- a/src/components/LogIn/LoginForm.js
+++ b/src/components/LogIn/LoginForm.js
@@ -14,8 +14,10 @@ import GoogleAuth from "../GoogleAuth/GoogleAuth";
 const LoginForm = () => {
   const { translations } = useLanguage();
   const router = useRouter();
+  // States for handling messages and loading
   const [msg, setMsg] = useState("");
   const [success, setSuccessStatus] = useState(null);
+  const [loading, setLoading] = useState(false);
 
   const { setStoredCredentials } = useContext(CredentialsContext);
 
@@ -25,11 +27,11 @@ const LoginForm = () => {
 
     if (success) {
       saveLoginCredentials(user);
-      handleMessage({ successStatus: true, msg: msg });
+      handleMessage({ successStatus: true, msg });
       router.push("/");
     } else {
       logInfo(msg);
-      handleMessage({ successStatus: false, msg: msg });
+      handleMessage({ successStatus: false, msg });
     }
   };
 
@@ -44,14 +46,12 @@ const LoginForm = () => {
   useEffect(() => {
     if (error) {
       const errorMessage = error.message || "An unexpected error occurred.";
-      handleMessage({
-        successStatus: false,
-        msg: errorMessage,
-      });
+      handleMessage({ successStatus: false, msg: errorMessage });
     }
   }, [error]);
 
   const handleLogin = (values, setSubmitting) => {
+    // Clear previous messages
     setMsg("");
     setSuccessStatus(null);
 
@@ -101,8 +101,8 @@ const LoginForm = () => {
 
   return (
     <div className="flex flex-col h-full" data-testid="login-container">
-      <main className="md:w-[18rem] lg:w-[25rem] flex flex-col justify-center items-center ">
-        <h2 className="mb-4 mt-2 text-headlineMedium self-start text-tertiary1-normal relative top-1">
+      <main className="md:w-[18rem] lg:w-[25rem] flex flex-col justify-center items-center">
+        <h2 className="mb-1 mt-1 text-headlineMedium self-start text-tertiary1-normal relative top-1">
           {translations["logIn.button"]}
         </h2>
         <Formik
@@ -157,15 +157,6 @@ const LoginForm = () => {
                   aria-label="Password"
                 />
               </div>
-              <div className="flex justify-center" data-testid="login-message">
-                <p
-                  className={`text-xs ${success ? "text-green-500" : "text-red-500"}`}
-                  aria-live="polite"
-                  data-testid="message-status"
-                >
-                  {msg}
-                </p>
-              </div>
               <div className="w-[17.5rem] md:w-[18rem] lg:w-[25rem] flex flex-col space-y-4">
                 <Button
                   text={translations["logIn.button"]}
@@ -175,9 +166,26 @@ const LoginForm = () => {
                   aria-label="Submit Log In"
                 />
               </div>
-              <GoogleAuth />
-
-              <div className="flex mt-4 space-x-1 items-center text-labelMedium relative bottom-1 p-2">
+              {/* Pass setMsg, setSuccess, and setLoading so GoogleAuth updates global state */}
+              <GoogleAuth
+                setMsg={setMsg}
+                setSuccess={setSuccessStatus}
+                setLoading={setLoading}
+              />
+              {/* Message container with fixed height to prevent inputs from moving */}
+              <div
+                className="flex justify-center min-h-[2rem]"
+                data-testid="login-message"
+              >
+                <p
+                  className={`text-labelLarge text-center ${loading ? "text-black" : success ? "text-green-500" : "text-red-500"}`}
+                  aria-live="polite"
+                  data-testid="message-status"
+                >
+                  {loading ? "Loading..." : msg}
+                </p>
+              </div>
+              <div className="flex !mt-1 !mb-1 space-x-1 items-center text-labelMedium relative bottom-1">
                 <Link
                   href="/forgotpassword"
                   data-testid="forget-password-link"
@@ -188,7 +196,7 @@ const LoginForm = () => {
                 </Link>
               </div>
               <div className="relative bottom-5 w-[17.5rem] md:w-[18rem] lg:w-[25rem]">
-                <h2 className="mb-4 mt-6 text-headlineMedium self-center sm:self-start text-tertiary1-normal">
+                <h2 className="mb-1 mt-1 text-headlineMedium self-center sm:self-start text-tertiary1-normal">
                   {translations["logIn.no-account"]}
                 </h2>
                 <Button
@@ -200,9 +208,8 @@ const LoginForm = () => {
                   onClick={() => router.push("/signup")}
                 />
               </div>
-              {/* Loading Indicator */}
               {isLoading && (
-                <div className="flex justify-center items-center mt-4">
+                <div className="flex justify-center items-center !mt-1">
                   <div className="w-8 h-8 border-4 border-t-4 border-blue-500 border-solid rounded-full animate-spin" />
                 </div>
               )}

--- a/src/components/LogIn/LoginForm.js
+++ b/src/components/LogIn/LoginForm.js
@@ -102,9 +102,11 @@ const LoginForm = () => {
   return (
     <div className="flex flex-col h-full" data-testid="login-container">
       <main className="md:w-[18rem] lg:w-[25rem] flex flex-col justify-center items-center">
-        <h2 className="mb-1 mt-1 text-headlineMedium self-start text-tertiary1-normal relative top-1">
-          {translations["logIn.button"]}
-        </h2>
+        <div className=" w-[17.5rem] md:w-[18rem] lg:w-[25rem] flex justify-start items-start">
+          <h2 className="mb-4 text-headlineMedium text-tertiary1-normal">
+            {translations["logIn.button"]}
+          </h2>
+        </div>
         <Formik
           initialValues={{ email: "", password: "" }}
           onSubmit={(values, { setSubmitting }) => {


### PR DESCRIPTION
- Centralized error and success messages in LoginForm so that both login and GoogleAuth messages display in one spot.
- Passed setMsg, setSuccess, and setLoading as props from LoginForm to GoogleAuth.
- Updated GoogleAuth to use these props for handling error messages and global loading state.
- We used to have this problem 
![image](https://github.com/user-attachments/assets/c98e6b29-a3b9-4ca9-ac2f-408e6b3e6610)
- Now it looks like this with all the succes and error messages in the same spot
![image](https://github.com/user-attachments/assets/5ff4dc46-ead9-49eb-b826-51c0c79622b2)
