### PR TITLE
Ensuring Button-component accepts linkUrl prop

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -2,6 +2,7 @@
 
 import React from "react";
 import PropTypes from "prop-types";
+import Link from "next/link";
 
 const BASE_BUTTON_CLASSES = `
   flex justify-center items-center h-[2.875rem] rounded-[0.3rem] bodyLarge
@@ -38,6 +39,8 @@ const Button = ({
   ariaLabel,
   testId,
   isLoading = false,
+  linkUrl,
+  linkWidth,
 }) => {
   const buttonClass = `
   ${BASE_BUTTON_CLASSES}
@@ -45,24 +48,38 @@ const Button = ({
   ${disabled || isLoading ? "opacity-50 cursor-not-allowed" : ""}
 `.trim();
 
-  return (
+  const buttonContent = (
     <button
       className={buttonClass}
       onClick={onClick}
       disabled={disabled || isLoading}
       aria-label={ariaLabel}
-      data-testid={testId}
+      data-testid={linkUrl ? undefined : testId}
       type={variant === "submit" ? "submit" : "button"}
     >
       {isLoading ? (
         "Submitting..."
       ) : (
         <>
-          {icon && <img src={icon} alt="Icon" className="mr-2" />}
+          {icon && (
+            <img src={icon} alt="Icon" className="mr-2" loading="lazy" />
+          )}
           {text}
         </>
       )}
     </button>
+  );
+
+  return linkUrl ? (
+    <Link
+      href={linkUrl}
+      data-testid={testId}
+      className={linkWidth || "w-full sm:w-[10.8rem]"}
+    >
+      {buttonContent}
+    </Link>
+  ) : (
+    buttonContent
   );
 };
 
@@ -71,17 +88,24 @@ Button.propTypes = {
   icon: PropTypes.string,
   variant: PropTypes.oneOf([
     "red",
+    "redFullText",
+    "redWide",
+    "lightRedWide",
     "redLine",
     "darkGreen",
     "grayGreen",
+    "greenSubmit",
     "redSubmit",
     "gray",
+    "yellow",
   ]),
   onClick: PropTypes.func,
   disabled: PropTypes.bool,
   ariaLabel: PropTypes.string,
   testId: PropTypes.string,
   isLoading: PropTypes.bool,
+  linkUrl: PropTypes.string,
+  linkWidth: PropTypes.string,
 };
 
 export default Button;

--- a/src/components/HeroSlider/HeroSlider.js
+++ b/src/components/HeroSlider/HeroSlider.js
@@ -34,7 +34,7 @@ const HeroSlider = () => {
     "/images/hero-newsletter.jpg",
   ];
 
-  // const urls = ["/events", "/shop", "/subscribe"];
+  const urls = ["/events", "/shop", "/subscribe"];
 
   // Logic for handling use of the prev/next-buttons
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
@@ -120,7 +120,7 @@ const HeroSlider = () => {
           variant="redFullText"
           aria-label="Book a tasting session"
           data-testid="book-tasting-button"
-          className=""
+          linkUrl={urls[currentImageIndex]}
         ></Button>
         <div
           className={`hidden md:flex mt-4 md:absolute md:bottom-8 lg:bottom-10 xl:bottom-14 ${currentImageIndex === 0 ? "md:right-8 lg:right-10 xl:right-12" : "md:left-[37.5%]"}`}


### PR DESCRIPTION
# Ensuring Button-component accepts linkUrl prop

This PR refers to task #112. I only fixed so that the <Button> component accept the linkUrl prop (as it does in the corporate website). I also made the buttons in the heroslider on the homepage hade linkUrls tied to them so that for example the events page can be reached by clicking the button on slide 1. This might come in handy now that we are going to work on the calendar booking.

### Changes
- Ensured button-component accepts linkUrl prop 
- Added urls to the buttons of the heroslider

### Preview (try cliking this button in the deployment to test the PR)
![buttonworking](https://github.com/user-attachments/assets/f0bac326-928d-48f2-afb4-af9b1df90ce6)
