### PR TITLE
[FIX]: Update Node.js Setup Sction from v2 to v4 in CI Workflow

### DIFF
--- a/.github/workflows/ci-tests-and-code-style.yml
+++ b/.github/workflows/ci-tests-and-code-style.yml
@@ -25,7 +25,7 @@ jobs:
 
       # 2. Set up Node.js
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"


### PR DESCRIPTION
## [FIX]: Update Node.js Setup Sction from v2 to v4 in CI Workflow

### Description
Updates GitHub Actions workflow to fix CI test failures by upgrading from setup-node@v2 to setup-node@v4. This resolves the "Cache service responded with 422" error by using the latest cache service implementation.