### PR TITLE
[FIX] Fix API URL Configuration with Adding Staging Mode

### DIFF
--- a/src/config/environment.js
+++ b/src/config/environment.js
@@ -1,11 +1,10 @@
 import { logInfo } from "@/utils/logging";
 
-const API_URL_LOCAL = process.env.NEXT_PUBLIC_API_URL_LOCAL;
-const API_URL_HEROKU = process.env.NEXT_PUBLIC_API_URL_HEROKU;
+const env = process.env.NODE_ENV || "development";
 
-const isProduction = process.env.NODE_ENV === "production";
-export const baseApiUrl = isProduction ? API_URL_HEROKU : API_URL_LOCAL;
+export const baseApiUrl =
+  env === "production" || env === "staging"
+    ? process.env.NEXT_PUBLIC_API_URL_HEROKU
+    : process.env.NEXT_PUBLIC_API_URL_LOCAL;
 
-logInfo(
-  `Server URL: ${baseApiUrl} (${isProduction ? "production" : "development"} mode)`,
-);
+logInfo(`Server URL: ${baseApiUrl} (${env} mode)`);


### PR DESCRIPTION
## [FIX] Fix API URL Configuration with Adding Staging Mode

### Changes

- Adds support for staging environments
- Automatically selects the appropriate backend API URL based on NODE_ENV
- Fixes issues with Heroku deployments by properly handling staging environments