### PR TITLE
Task #161 - Calendar style fixes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Barlow:wght@300;700&family=Roboto:wght@300;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Barlow:wght@300;400;500;600;700&family=Roboto:wght@300;700&display=swap");
 
 @tailwind base;
 @tailwind components;

--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -130,7 +130,7 @@ const Calendar = ({ currentYear, currentMonth }) => {
     "flex bg-primary-normal h-11 md:h-4 justify-center items-center text-labelLarge md:text-labelMedium text-tertiary2-light";
 
   return (
-    <section className="grid grid-cols-7 grid-row-5 justify-center w-full md:max-w-[calc(7*6.22rem-8px)] lg:md:max-w-[calc(7*6.22rem)] mx-auto border-b-tertiary1-light border-[1px] rounded-b-lg">
+    <section className="grid grid-cols-7 grid-row-5 justify-center w-full md:max-w-[calc(7*6.282rem-8px)] lg:md:max-w-[calc(7*6.282rem)] mx-auto border-b-tertiary1-light border-[1px] rounded-b-lg">
       {[...Array(7)].map((_, i) => (
         <div key={i} className={weekdayStyle}>
           {isMobile

--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -9,7 +9,7 @@ const Calendar = ({ currentYear, currentMonth }) => {
   const { events } = useEvents();
 
   const [isMobile, setIsMobile] = React.useState(
-    typeof window !== "undefined" && window.innerWidth < 1024,
+    typeof window !== "undefined" && window.innerWidth < 768,
   );
   const [isModalOpen, setIsModalOpen] = useState(true);
   const [selectedEvent, setSelectedEvent] = useState(null);
@@ -26,7 +26,7 @@ const Calendar = ({ currentYear, currentMonth }) => {
 
   React.useEffect(() => {
     const handleResize = () => {
-      setIsMobile(window.innerWidth < 1024);
+      setIsMobile(window.innerWidth < 768);
     };
 
     window.addEventListener("resize", handleResize);
@@ -127,7 +127,7 @@ const Calendar = ({ currentYear, currentMonth }) => {
   );
 
   const weekdayStyle =
-    "flex bg-primary-normal h-11 lg:h-16 justify-center items-center text-labelLarge md:text-titleMedium lg:text-labelLarge text-tertiary2-light";
+    "flex bg-primary-normal h-11 md:h-4 justify-center items-center text-labelLarge md:text-labelMedium text-tertiary2-light";
 
   return (
     <section className="grid grid-cols-7 grid-row-5 justify-center w-full md:max-w-[calc(7*6.22rem-8px)] lg:md:max-w-[calc(7*6.22rem)] mx-auto border-b-tertiary1-light border-[1px] rounded-b-lg">

--- a/src/components/Calendar/CalendarItem.js
+++ b/src/components/Calendar/CalendarItem.js
@@ -81,7 +81,7 @@ const CalendarItem = ({
                 inline-flex items-center justify-center w-6 h-6 rounded-full border-2
                 ${percentageAvailable <= 50 ? "border-calendar-today_ring" : ""}
                 ${percentageAvailable > 50 ? "border-primary-active" : ""}
-                relative right-[6px]
+                relative bottom-[2px]
               `}
             >
               {dayOfMonth}

--- a/src/components/Calendar/CalendarItem.js
+++ b/src/components/Calendar/CalendarItem.js
@@ -62,7 +62,7 @@ const CalendarItem = ({
 
   return (
     <article
-      className={`relative min-w-[2.618rem] min-h-[2.813rem] lg:h-[4.976rem] lg:w-[6.22rem] bg-transparent border-tertiary1-light border-t-[1px] ${!isLeft && !isRight ? "border-r-[1px]" : ""} ${isLeft ? "border-r-[1px]" : ""}  
+      className={`relative min-w-[2.618rem] min-h-[2.813rem] lg:h-[4.976rem] lg:w-[6.282rem] bg-transparent border-tertiary1-light border-t-[1px] ${!isLeft && !isRight ? "border-r-[1px]" : ""} ${isLeft ? "border-r-[1px]" : ""}  
         ${isFull ? "hover:cursor-not-allowed" : "hover:cursor-pointer"} 
        `}
       onClick={onClick}
@@ -80,7 +80,7 @@ const CalendarItem = ({
                 inline-flex items-center justify-center w-6 h-6 rounded-full border-2
                 ${percentageAvailable <= 50 ? "border-calendar-today_ring" : ""}
                 ${percentageAvailable > 50 ? "border-primary-active" : ""}
-                relative bottom-1 right-1
+                relative bottom-[2px] md:bottom-1 md:right-[6px]
               `}
             >
               {dayOfMonth}

--- a/src/components/Calendar/CalendarItem.js
+++ b/src/components/Calendar/CalendarItem.js
@@ -17,11 +17,13 @@ const CalendarItem = ({
 }) => {
   const { translations } = useLanguage();
   const isFull = availableSeats === 0 && totalInventory > 0;
+  const isLeft = index % 7 === 0; // Check if the item is on the left side of the calendar
+  const isRight = (index + 1) % 7 === 0; // Check if the item is on the right side of the calendar
   const percentageAvailable =
     totalInventory > 0 ? (availableSeats / totalInventory) * 100 : 0;
 
   const BASE_CALENDARITEM_CLASSES = `
-   min-w-[2.818rem] min-h-[2.813rem] md:min-h-[4.813rem] lg:h-[4.926rem] ${(index + 1) % 7 === 0 ? "lg:w-[6.12rem]" : "lg:w-[6.20rem]"} text-labelXLarge font-semibold rounded-tl-[6px] rounded-bl-[20px] md:rounded-tl-[12px] md:rounded-bl-[40px] lg:rounded-tl-[6px] lg:rounded-bl-[24px]
+   min-w-[99%] min-h-[2.813rem] md:min-h-[4.813rem] lg:h-[4.926rem] ${(index + 1) % 7 === 0 ? "lg:w-[6.12rem]" : "lg:w-[6.20rem]"} text-labelXLarge font-semibold rounded-tl-[6px] rounded-bl-[20px] md:rounded-tl-[12px] md:rounded-bl-[40px] lg:rounded-tl-[6px] lg:rounded-bl-[24px]
 `;
 
   // Get today's date
@@ -61,7 +63,7 @@ const CalendarItem = ({
 
   return (
     <article
-      className={`relative min-w-[2.818rem] min-h-[2.813rem] lg:h-[4.976rem] lg:w-[6.22rem] bg-transparent border-tertiary1-light border-t-[1px] border-x-[1px] 
+      className={`relative min-w-[2.618rem] min-h-[2.813rem] lg:h-[4.976rem] lg:w-[6.22rem] bg-transparent border-tertiary1-light border-t-[1px] ${!isLeft && !isRight ? "border-r-[1px]" : ""} ${isLeft ? "border-r-[1px]" : ""}  
         ${isFull ? "hover:cursor-not-allowed" : "hover:cursor-pointer"} 
        `}
       onClick={onClick}

--- a/src/components/Calendar/CalendarItem.js
+++ b/src/components/Calendar/CalendarItem.js
@@ -6,7 +6,6 @@ import { useLanguage } from "@/context/LanguageContext";
 
 const CalendarItem = ({
   dayOfMonth,
-  icon,
   index,
   availableSeats = 0,
   totalInventory = 0,
@@ -23,7 +22,7 @@ const CalendarItem = ({
     totalInventory > 0 ? (availableSeats / totalInventory) * 100 : undefined;
 
   const BASE_CALENDARITEM_CLASSES = `
-   min-w-[99%] min-h-[2.813rem] md:min-h-[4.813rem] lg:h-[4.926rem] ${(index + 1) % 7 === 0 ? "lg:w-[6.12rem]" : "lg:w-[6.20rem]"} text-labelXLarge font-semibold rounded-tl-[6px] rounded-bl-[20px] md:rounded-tl-[12px] md:rounded-bl-[40px] lg:rounded-tl-[6px] lg:rounded-bl-[24px]
+   min-w-[99%] min-h-[2.813rem] md:min-h-[4.813rem] lg:h-[4.926rem] ${(index + 1) % 7 === 0 ? "lg:w-[6.12rem]" : "lg:w-[6.20rem]"} text-labelXLarge font-semibold rounded-tl-[6px] rounded-bl-[20px] md:rounded-tl-[0px] md:rounded-bl-[16px]
 `;
 
   // Get today's date
@@ -72,7 +71,7 @@ const CalendarItem = ({
         className={`${calendarItemClass} 
         `}
       >
-        <p className="flex justify-center pt-3 md:h-auto md:absolute md:left-4 md:pt-4 text-labelLarge">
+        <p className="flex justify-center pt-3 md:h-auto md:absolute md:left-2 md:pt-[5px] font-medium text-labelLarge md:text-labelMedium">
           {isToday &&
           isCurrentYear &&
           typeof percentageAvailable === "number" ? (
@@ -81,7 +80,7 @@ const CalendarItem = ({
                 inline-flex items-center justify-center w-6 h-6 rounded-full border-2
                 ${percentageAvailable <= 50 ? "border-calendar-today_ring" : ""}
                 ${percentageAvailable > 50 ? "border-primary-active" : ""}
-                relative bottom-[2px]
+                relative bottom-1 right-1
               `}
             >
               {dayOfMonth}
@@ -91,13 +90,13 @@ const CalendarItem = ({
           )}
         </p>
         {availableSeats >= 0 && totalInventory !== 0 && !isOtherMonth ? (
-          <div className="justify-end items-center md:gap-[4px] absolute bottom-3 right-2 md:right-1 hidden md:flex">
-            <img
+          <div className="justify-end items-center md:gap-[4px] absolute bottom-1 right-2 md:right-2 hidden md:flex">
+            {/* <img
               src={icon}
               alt="attendants icon"
               className="object-center w-4 h-5"
-            />
-            <p className="text-white text-labelMedium">{`${translations["calendar.seats"]}: ${availableSeats}`}</p>
+            /> */}
+            <p className="text-white text-labelMedium font-medium">{`${translations["calendar.seats"]}: ${availableSeats}`}</p>
           </div>
         ) : null}
       </div>

--- a/src/components/Calendar/CalendarItem.js
+++ b/src/components/Calendar/CalendarItem.js
@@ -20,7 +20,7 @@ const CalendarItem = ({
   const isLeft = index % 7 === 0; // Check if the item is on the left side of the calendar
   const isRight = (index + 1) % 7 === 0; // Check if the item is on the right side of the calendar
   const percentageAvailable =
-    totalInventory > 0 ? (availableSeats / totalInventory) * 100 : 0;
+    totalInventory > 0 ? (availableSeats / totalInventory) * 100 : undefined;
 
   const BASE_CALENDARITEM_CLASSES = `
    min-w-[99%] min-h-[2.813rem] md:min-h-[4.813rem] lg:h-[4.926rem] ${(index + 1) % 7 === 0 ? "lg:w-[6.12rem]" : "lg:w-[6.20rem]"} text-labelXLarge font-semibold rounded-tl-[6px] rounded-bl-[20px] md:rounded-tl-[12px] md:rounded-bl-[40px] lg:rounded-tl-[6px] lg:rounded-bl-[24px]
@@ -73,9 +73,16 @@ const CalendarItem = ({
         `}
       >
         <p className="flex justify-center pt-3 md:h-auto md:absolute md:left-4 md:pt-4 text-labelLarge">
-          {isToday && isCurrentYear ? (
+          {isToday &&
+          isCurrentYear &&
+          typeof percentageAvailable === "number" ? (
             <span
-              className={`inline-flex items-center justify-center w-6 h-6 rounded-full border-2 ${percentageAvailable <= 50 && percentageAvailable !== null ? "border-calendar-today_ring" : "border-primary-active"}  relative right-[6px]`}
+              className={`
+                inline-flex items-center justify-center w-6 h-6 rounded-full border-2
+                ${percentageAvailable <= 50 ? "border-calendar-today_ring" : ""}
+                ${percentageAvailable > 50 ? "border-primary-active" : ""}
+                relative right-[6px]
+              `}
             >
               {dayOfMonth}
             </span>

--- a/src/components/Calendar/CalendarMonthPicker.js
+++ b/src/components/Calendar/CalendarMonthPicker.js
@@ -36,21 +36,21 @@ const CalendarMonthPicker = ({ currentMonth, currentYear, onMonthChange }) => {
   };
 
   return (
-    <div className="flex justify-between items-center mx-auto bg-primary-active_normal w-full h-[3.438rem] lg:h-[5rem] md:max-w-[calc(7*6.22rem-10px)] lg:md:max-w-[calc(7*6.22rem-2px)] rounded-t-[0.5rem] text-titleLarge lg:text-headlineMedium text-center text-tertiary2-light">
+    <div className="flex justify-between items-center mx-auto bg-primary-active_normal w-full h-[3.438rem] md:h-[2.25rem] md:max-w-[calc(7*6.22rem-10px)] lg:md:max-w-[calc(7*6.22rem-2px)] rounded-t-[0.5rem] text-titleMedium lg:text-titleSmall text-center text-tertiary2-light">
       <button
         onClick={handlePreviousMonth}
         aria-label="Previous Month"
-        className="relative top-[2px] left-6 md:left-10 lg:left-16"
+        className="relative left-6 md:left-10 lg:left-18"
       >
-        <img src="/icons/arrow-left-small.svg" />
+        <img src="/icons/arrow-left-small.svg" className="w-4 h-4" />
       </button>
       {months[currentMonth - 1]} {currentYear}
       <button
         onClick={handleNextMonth}
         aria-label="Next Month"
-        className="relative top-[2px] right-6 md:right-10 lg:right-16"
+        className="relative right-6 md:right-10 lg:right-18"
       >
-        <img src="/icons/arrow-right-small.svg" />
+        <img src="/icons/arrow-right-small.svg" className="w-4 h-4" />
       </button>
     </div>
   );

--- a/src/components/Calendar/CalendarMonthPicker.js
+++ b/src/components/Calendar/CalendarMonthPicker.js
@@ -36,7 +36,7 @@ const CalendarMonthPicker = ({ currentMonth, currentYear, onMonthChange }) => {
   };
 
   return (
-    <div className="flex justify-between items-center mx-auto bg-primary-active_normal w-full h-[3.438rem] md:h-[2.25rem] md:max-w-[calc(7*6.22rem-10px)] lg:md:max-w-[calc(7*6.22rem-2px)] rounded-t-[0.5rem] text-titleMedium lg:text-titleSmall text-center text-tertiary2-light">
+    <div className="flex justify-between items-center mx-auto bg-primary-active_normal w-full h-[3.438rem] md:h-[2.25rem] md:max-w-[calc(7*6.282rem-2px)] lg:md:max-w-[calc(7*6.6.282rem-2px)] rounded-t-[0.5rem] text-titleMedium lg:text-titleSmall text-center text-tertiary2-light">
       <button
         onClick={handlePreviousMonth}
         aria-label="Previous Month"

--- a/src/components/Calendar/ColorInfo.js
+++ b/src/components/Calendar/ColorInfo.js
@@ -5,7 +5,7 @@ const ColorInfo = () => {
   const { translations } = useLanguage();
 
   return (
-    <div className="flex justify-center items-center rounded-[0.5rem] bg-tertiary2-normal h-[88px] md:h-10 mt-3 w-full md:max-w-[calc(7*6.22rem-6px)] lg:md:max-w-[calc(7*6.22rem-2px)]">
+    <div className="flex justify-center items-center rounded-[0.5rem] bg-tertiary2-normal h-[88px] md:h-10 mt-3 w-full md:max-w-[calc(7*6.282rem-6px)] lg:md:max-w-[calc(7*6.282rem-2px)]">
       <div className="grid grid-cols-2 px-2 gap-6 justify-space-between md:gap-4 md:flex md:flex-row justify-center items-center">
         {[
           { color: "bg-primary-active", key: "today" },

--- a/src/components/Calendar/DateSelector.js
+++ b/src/components/Calendar/DateSelector.js
@@ -20,7 +20,7 @@ const DateSelector = ({ currentMonth, currentYear, onMonthChange }) => {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <section className="flex justify-center items-center mx-auto bg-primary-light w-full h-[3.125rem] lg:h-[4rem] max-w-[calc(7*6.22rem-4px)] mb-4 rounded-lg">
+      <section className="flex justify-center items-center mx-auto bg-primary-light w-full h-[3.125rem] lg:h-[4rem] max-w-[calc(7*6.282rem-4px)] mb-4 rounded-lg">
         <div className="flex justify-between lg:justify-center gap-2 hover:cursor-pointer">
           <p
             className="text-titleMedium md:text-headlineSmall text-tertiary1-darker ml-6 lg:ml-0"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -135,7 +135,7 @@
   "calendar.colorinfo.today": "Today's date",
   "calendar.colorinfo.available": "Available seats",
   "calendar.colorinfo.limited": "Only few seats left",
-  "calendar.colorinfo.full": "No more seats available",
+  "calendar.colorinfo.full": "No seats available",
   "events.error.loading": "Failed to load events. Please try again later.",
   "common.loading": "Loading...",
   "common.submitting": "Submitting...",


### PR DESCRIPTION
This task refers to task #161. The calendar needed some style and logic fixes, in order to match the figma and display colors and border correctly.

### Fixes
- I removed some "double border" that were appearing in mobile mode
- I made the pink ring (showing today's date on days when there are events) not appear on today's date
- I did some styling updates to match figma (sizes, rounding)
- I updated the import statement in globals.css to allow for more accurate font-weights

### Preview
![calendar-updated](https://github.com/user-attachments/assets/959627f9-29dc-497c-bc1b-ef15f085dc4f)
