### PR TITLE
Creating "Add to cart"-button that connects to Shopify Checkout

### DIFF
--- a/src/components/Button/ShopifyBuyButton.js
+++ b/src/components/Button/ShopifyBuyButton.js
@@ -1,0 +1,97 @@
+// components/ShopifyBuyButton.js
+"use client"; // Only if you're in an app directory in Next.js 13+
+
+import React from "react";
+import { useEffect, useRef } from "react";
+
+const ShopifyBuyButton = () => {
+  const buyButtonRef = useRef(null);
+
+  useEffect(() => {
+    const scriptURL =
+      "https://sdks.shopifycdn.com/buy-button/latest/buy-button-storefront.min.js";
+
+    const loadScript = () => {
+      const script = document.createElement("script");
+      script.async = true;
+      script.src = scriptURL;
+      document.head.appendChild(script);
+      script.onload = ShopifyBuyInit;
+    };
+
+    const ShopifyBuyInit = () => {
+      if (!window.ShopifyBuy) return;
+      if (window.ShopifyBuy.UI) {
+        const client = window.ShopifyBuy.buildClient({
+          domain: "0qqxpn-qp.myshopify.com",
+          storefrontAccessToken: "74cc29d0ddd9227dd753037748de8685",
+        });
+
+        window.ShopifyBuy.UI.onReady(client).then((ui) => {
+          ui.createComponent("product", {
+            id: "10153455092058",
+            node: buyButtonRef.current,
+            moneyFormat: "%7B%7Bamount_with_comma_separator%7D%7D%20kr",
+            options: {
+              product: {
+                styles: {
+                  product: {
+                    "@media (min-width: 601px)": {
+                      "max-width": "calc(25% - 20px)",
+                      "margin-left": "20px",
+                      "margin-bottom": "50px",
+                    },
+                  },
+                  button: {
+                    "font-family": "Lato, sans-serif",
+                    "font-weight": "bold",
+                    "font-size": "16px",
+                    "padding-top": "16px",
+                    "padding-bottom": "16px",
+                    ":hover": {
+                      "background-color": "#516ce6",
+                    },
+                    "background-color": "#5a78ff",
+                    ":focus": {
+                      "background-color": "#516ce6",
+                    },
+                  },
+                  quantityInput: {
+                    "font-size": "16px",
+                    "padding-top": "16px",
+                    "padding-bottom": "16px",
+                  },
+                },
+                buttonDestination: "checkout",
+                contents: {
+                  img: false,
+                  title: false,
+                  price: false,
+                },
+                text: {
+                  button: "Checkout",
+                },
+                googleFonts: ["Lato"],
+              },
+              // Include other options like cart, modalProduct, toggle if needed
+            },
+          });
+        });
+      }
+    };
+
+    if (window.ShopifyBuy) {
+      if (window.ShopifyBuy.UI) {
+        ShopifyBuyInit();
+      } else {
+        loadScript();
+      }
+    } else {
+      loadScript();
+    }
+  }, []);
+
+  return <div ref={buyButtonRef} />;
+};
+
+export default ShopifyBuyButton;

--- a/src/components/Button/ShopifyCartButton.js
+++ b/src/components/Button/ShopifyCartButton.js
@@ -1,0 +1,168 @@
+"use client"; // for Next.js 13+ if you're using app directory
+import React from "react";
+import { useEffect, useRef } from "react";
+let shopifyInitialized = 0;
+
+export default function ShopifyBuyButton() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    let isScriptLoaded = !!window.ShopifyBuy;
+
+    const loadShopifyScript = () => {
+      const script = document.createElement("script");
+      script.async = true;
+      script.src =
+        "https://sdks.shopifycdn.com/buy-button/latest/buy-button-storefront.min.js";
+      script.onload = initShopifyBuy;
+      document.head.appendChild(script);
+    };
+
+    const initShopifyBuy = () => {
+      if (
+        shopifyInitialized == 1 ||
+        containerRef.current?.childElementCount > 0
+      )
+        return;
+      shopifyInitialized++;
+
+      const client = window.ShopifyBuy.buildClient({
+        domain: "0qqxpn-qp.myshopify.com",
+        storefrontAccessToken: "74cc29d0ddd9227dd753037748de8685",
+      });
+
+      window.ShopifyBuy.UI.onReady(client).then((ui) => {
+        ui.createComponent("product", {
+          id: "10153455092058",
+          node: containerRef.current,
+          moneyFormat: "{{amount_with_comma_separator}} kr",
+          options: {
+            product: {
+              styles: {
+                product: {
+                  "@media (min-width: 601px)": {
+                    maxWidth: "calc(25% - 20px)",
+                    marginLeft: "20px",
+                    marginBottom: "50px",
+                  },
+                },
+                button: {
+                  fontFamily: "Lato, sans-serif",
+                  fontWeight: "bold",
+                  fontSize: "16px",
+                  paddingTop: "16px",
+                  paddingBottom: "16px",
+                  backgroundColor: "#5a78ff",
+                  ":hover": { backgroundColor: "#516ce6" },
+                  ":focus": { backgroundColor: "#516ce6" },
+                },
+                quantityInput: {
+                  fontSize: "16px",
+                  paddingTop: "16px",
+                  paddingBottom: "16px",
+                },
+              },
+              contents: {
+                img: false,
+                title: false,
+                price: false,
+              },
+              text: {
+                button: "Add to cart",
+              },
+              googleFonts: ["Lato"],
+            },
+            productSet: {
+              styles: {
+                products: {
+                  "@media (min-width: 601px)": {
+                    marginLeft: "-20px",
+                  },
+                },
+              },
+            },
+            modalProduct: {
+              contents: {
+                img: false,
+                imgWithCarousel: true,
+                button: false,
+                buttonWithQuantity: true,
+              },
+              styles: {
+                product: {
+                  "@media (min-width: 601px)": {
+                    maxWidth: "100%",
+                    marginLeft: "0px",
+                    marginBottom: "0px",
+                  },
+                },
+                button: {
+                  fontFamily: "Lato, sans-serif",
+                  fontWeight: "bold",
+                  fontSize: "16px",
+                  paddingTop: "16px",
+                  paddingBottom: "16px",
+                  backgroundColor: "#5a78ff",
+                  ":hover": { backgroundColor: "#516ce6" },
+                  ":focus": { backgroundColor: "#516ce6" },
+                },
+                quantityInput: {
+                  fontSize: "16px",
+                  paddingTop: "16px",
+                  paddingBottom: "16px",
+                },
+              },
+              googleFonts: ["Lato"],
+              text: {
+                button: "Add to cart",
+              },
+            },
+            option: {},
+            cart: {
+              styles: {
+                button: {
+                  fontFamily: "Lato, sans-serif",
+                  fontWeight: "bold",
+                  fontSize: "16px",
+                  paddingTop: "16px",
+                  paddingBottom: "16px",
+                  backgroundColor: "#5a78ff",
+                  ":hover": { backgroundColor: "#516ce6" },
+                  ":focus": { backgroundColor: "#516ce6" },
+                },
+              },
+              text: {
+                total: "Subtotal",
+                button: "Checkout",
+              },
+              googleFonts: ["Lato"],
+            },
+            toggle: {
+              styles: {
+                toggle: {
+                  fontFamily: "Lato, sans-serif",
+                  fontWeight: "bold",
+                  backgroundColor: "#5a78ff",
+                  ":hover": { backgroundColor: "#516ce6" },
+                  ":focus": { backgroundColor: "#516ce6" },
+                },
+                count: {
+                  fontSize: "16px",
+                },
+              },
+              googleFonts: ["Lato"],
+            },
+          },
+        });
+      });
+    };
+
+    if (isScriptLoaded && window.ShopifyBuy.UI) {
+      initShopifyBuy();
+    } else {
+      loadShopifyScript();
+    }
+  }, []);
+
+  return <div ref={containerRef} />;
+}

--- a/src/components/EventRegistrationModal/Registration.js
+++ b/src/components/EventRegistrationModal/Registration.js
@@ -25,9 +25,9 @@ function Registration({ eventDetails = {}, onClose }) {
       <h3 className="mb-4 text-center font-barlow text-headlineSmall font-medium">
         {translations["event.registration.title"]}
       </h3>
-      <form onSubmit={handleSubmit}>
-        <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2">
-          <div>
+      {/* <form onSubmit={handleSubmit}> */}
+      {/* <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2">  */}
+      {/* <div>
             <input
               type="text"
               id="firstName"
@@ -38,8 +38,8 @@ function Registration({ eventDetails = {}, onClose }) {
               className="w-full rounded border border-tertiary2-normal p-2 text-bodyLarge"
               placeholder={translations["event.registration.form.firstName"]}
             />
-          </div>
-          <div>
+          </div> */}
+      {/* <div>
             <input
               type="text"
               id="lastName"
@@ -50,10 +50,10 @@ function Registration({ eventDetails = {}, onClose }) {
               className="w-full rounded border border-tertiary2-normal p-2 text-bodyLarge"
               placeholder={translations["event.registration.form.lastName"]}
             />
-          </div>
+          </div> 
         </div>
-        <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2">
-          <div>
+        <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2">*/}
+      {/* <div>
             <input
               type="email"
               id="email"
@@ -64,8 +64,8 @@ function Registration({ eventDetails = {}, onClose }) {
               className="w-full rounded border border-tertiary2-normal p-2 text-bodyLarge"
               placeholder={translations["event.registration.form.email"]}
             />
-          </div>
-          <div>
+          </div> */}
+      {/* <div>
             <input
               type="email"
               id="confirmEmail"
@@ -77,8 +77,8 @@ function Registration({ eventDetails = {}, onClose }) {
               placeholder={translations["event.registration.form.confirmEmail"]}
             />
           </div>
-        </div>
-        <div className="mb-4">
+        </div> */}
+      {/* <div className="mb-4">
           <input
             type="tel"
             id="phone"
@@ -89,9 +89,9 @@ function Registration({ eventDetails = {}, onClose }) {
             className="w-full rounded border border-tertiary2-normal p-2 text-bodyLarge md:w-[49%]"
             placeholder={translations["event.registration.form.phone"]}
           />
-        </div>
-        <div className="mb-4 flex flex-col space-x-6 sm:flex-row md:flex-row">
-          <div>
+        </div> */}
+      {/* <div className="mb-4 flex flex-col space-x-6 sm:flex-row md:flex-row"> */}
+      {/* <div>
             <label
               htmlFor="seats"
               className="mb-1 block text-bodyMedium font-medium"
@@ -101,8 +101,8 @@ function Registration({ eventDetails = {}, onClose }) {
             <p className="mb-2 text-bodySmall text-tertiary1-normal">
               {translations["event.registration.form.selectSeats"]}
             </p>
-          </div>
-          <div className="flex items-center gap-9">
+          </div> */}
+      {/* <div className="flex items-center gap-9">
             <div className="flex items-center gap-2">
               <button
                 type="button"
@@ -139,36 +139,36 @@ function Registration({ eventDetails = {}, onClose }) {
               </p>
             </div>
           </div>
-        </div>
-        <div className="mb-6 flex items-center">
-          <input
-            type="checkbox"
-            id="agree"
-            name="agree"
-            checked={agree}
-            onChange={(e) => setAgree(e.target.checked)}
-            required
-            className="mr-2 accent-primary-normal"
-          />
-          <label htmlFor="agree" className="text-bodySmall">
-            {translations["event.registration.form.acceptTerms"]}
-          </label>
-        </div>
-        <div className="flex w-full flex-col md:flex-row md:items-center md:justify-between">
-          <div className="mb-4 flex w-full flex-col gap-2 md:mb-0 md:flex-row">
-            <button
-              type="button"
-              className="w-full rounded bg-primary-normal px-4 py-2 font-medium text-white hover:bg-primary-hover_normal md:flex-1"
-              onClick={onClose}
-            >
-              {translations["event.registration.form.close"]}
-            </button>
+        </div> */}
+      <div className="mb-6 flex items-center">
+        <input
+          type="checkbox"
+          id="agree"
+          name="agree"
+          checked={agree}
+          onChange={(e) => setAgree(e.target.checked)}
+          required
+          className="mr-2 accent-primary-normal"
+        />
+        <label htmlFor="agree" className="text-bodySmall">
+          {translations["event.registration.form.acceptTerms"]}
+        </label>
+      </div>
+      <div className="flex w-full flex-col md:flex-row md:items-center md:justify-between">
+        <div className="mb-4 flex w-full flex-col gap-2 md:mb-0 md:flex-row">
+          <button
+            type="button"
+            className="relative top-5 max-h-[2.625rem] w-full rounded bg-primary-normal px-4 py-2 font-medium text-white hover:bg-primary-hover_normal md:flex-1"
+            onClick={onClose}
+          >
+            {translations["event.registration.form.close"]}
+          </button>
 
-            {/* <ShopifyBuyButton /> */}
-            <ShopifyCartButton />
-          </div>
+          {/* <ShopifyBuyButton /> */}
+          <ShopifyCartButton />
         </div>
-      </form>
+      </div>
+      {/* </form> */}
     </>
   );
 }

--- a/src/components/EventRegistrationModal/Registration.js
+++ b/src/components/EventRegistrationModal/Registration.js
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { useLanguage } from "@/context/LanguageContext";
+import ShopifyBuyButton from "@/components/Button/ShopifyBuyButton";
+import ShopifyCartButton from "@/components/Button/ShopifyCartButton";
 
 function Registration({ eventDetails = {}, onClose }) {
   const { translations } = useLanguage();
@@ -162,18 +164,8 @@ function Registration({ eventDetails = {}, onClose }) {
               {translations["event.registration.form.close"]}
             </button>
 
-            <button
-              type="submit"
-              className="flex w-full items-center justify-center gap-2 rounded bg-blue-500 px-4 py-2 font-medium text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:bg-blue-500 disabled:opacity-50 disabled:hover:bg-blue-500 md:flex-1"
-              disabled={!agree || availableSeats === 0}
-            >
-              <span>{translations["event.registration.form.payWith"]}</span>
-              <img
-                src="/icons/brand.svg"
-                alt="MobilePay Logo"
-                className="h-8 !w-[7rem]"
-              />
-            </button>
+            {/* <ShopifyBuyButton /> */}
+            <ShopifyCartButton />
           </div>
         </div>
       </form>

--- a/src/translations/dk.json
+++ b/src/translations/dk.json
@@ -171,7 +171,7 @@
   "event.details.allergies": "(*) Ved allergier eller særlige anmodninger, kontakt os venligst efter bekræftelse af din reservation.",
   "event.details.wineCard.title": "Vores Vine",
   "event.details.menuCard.title": "Vores Middagsmenu",
-  "event.registration.title": "Kontaktoplysninger til reservation",
+  "event.registration.title": "Registrere for begivenheden",
   "event.registration.form.firstName": "Fornavn*",
   "event.registration.form.lastName": "Efternavn*",
   "event.registration.form.email": "E-mail adresse*",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -171,7 +171,7 @@
   "event.details.allergies": "(*) For allergies or special requests, please contact us after confirming your reservation.",
   "event.details.wineCard.title": "Our Wines",
   "event.details.menuCard.title": "Our Dinner Menu",
-  "event.registration.title": "Reservation contacts details",
+  "event.registration.title": "Reserve this event",
   "event.registration.form.firstName": "First Name*",
   "event.registration.form.lastName": "Last Name*",
   "event.registration.form.email": "Email Address*",


### PR DESCRIPTION
# Creating the "Add to cart"-button

Shopify has an app called "[Buy Button](https://www.shopify.com/se/kop-knapp)" which enables a button that you can place on your website that leads to the checkout popup of a specific shopify event (which you specify when creating the button). For this PR I simply chose one event from our shopify shop that the button will link to inside of the Buy Button-app.
I created 2 different React-components of the code that was generated by the app called:

- ShopifyBuyButton - Makes a window popup with the checkout of the event
- ShopifyCartButton - Makes a sidebar with the shopping cart of the user pops up (see images below)

---

## Description

This PR 

- Creates a button which can connect to shopify checkout
- We can let our customers buy specific event tickets
- If we choose the ShopifyCartButton customers will be able to 
choose the amount they want to purchase in the sidebar
- Removes some of the input-fields that wont be needed for this solution
- Basic styling of the buttons two buttons (design probably needs to change to align with our design)

---

## Screenshots (if applicable)

#### The button looks like this at the moment:
![add-to-cart](https://github.com/user-attachments/assets/72fc8734-3262-4c13-ba55-fda30e60cbcf)

========================================================================

#### When clicking the ShopifyCartButton the sidebar pops from the right (where you can select the amount you want):
![sidebar](https://github.com/user-attachments/assets/767afecc-dd24-44e8-ae52-18fcf33aa5df)

========================================================================

#### When the Checkout-button at the bottom is clicked, this leads to the a shopify checkout opens in a new window:
![shop-popup](https://github.com/user-attachments/assets/7cbff3be-deda-479d-bd19-9a37496a0010)

Here you can but your event-tickets (it works)
---

## Testing Steps

Explain how reviewers can test this PR locally.

1. Just checkout to this branch (or check deployment)
2. You should be able to book an avent, and see the "Add to cart"-button
3. You should be able to see the sidebar pop out
4. You should be able to buy the event if you would want to (but don't do it it will be expensive)
5. Try uncommenting the code for the ShopifyBuyButton to render that instead, and see what clicking that button will do. This one looks 

---

## Things to improve / Features to add in the future
 - Dynamically gathering event info from the events to the button needs to be implemented in a future PR. 
 - The button takes a little time to load (maybe could be good with a spinner or loading icon here) before that.
 - Improve styling of the buttons
 - Change color on the "Add to cart"-button