### PR TITLE
[FEATURE] Improve Navigation Feedback with Loading States and Not-Found Pages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,16 +2,12 @@
 
 **Example:** [FEATURE] Implement Login Functionality
 
----
-
 ## Description
 
 Provide a brief summary of what this PR does. Include context, objectives, and any other relevant information.
 
 - What problem does this PR solve?
 - What is the impact of the change?
-
----
 
 ## Changes Made
 
@@ -22,13 +18,9 @@ List the main changes in this pull request. Describe what was added, modified, o
 - **Styling:** Updates to CSS, themes, or design tokens?
 - **Dependencies:** New packages or updates?
 
----
-
 ## Screenshots (if applicable)
 
 Add screenshots, GIFs, or videos that demonstrate the functionality or UI changes.
-
----
 
 ## Testing Steps
 
@@ -38,15 +30,11 @@ Explain how reviewers can test this PR locally.
 2. **Steps:** Step-by-step instructions to verify the changes.
 3. **Expected Result:** What should reviewers see or experience?
 
----
-
 ## Issues Addressed
 
 Link any GitHub issues that this pull request addresses (if any).
 
 **Example:** Closes #123 (link to GitHub issue)
-
----
 
 ## Additional Notes
 

--- a/src/__tests__/appTest/loading.test.js
+++ b/src/__tests__/appTest/loading.test.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import RootLoading from "@/app/loading";
+import Spinner from "@/components/UI/Spinner";
+
+jest.mock("@/components/UI/Spinner", () => {
+  return jest.fn(() => <div data-testid="spinner-mock" />);
+});
+
+describe("RootLoading", () => {
+  it("should render the loading overlay", () => {
+    render(<RootLoading />);
+
+    const overlay = screen.getByTestId("spinner-mock").parentElement;
+    expect(overlay).toHaveClass(
+      "fixed inset-0 z-50 flex items-center justify-center bg-white/80 backdrop-blur-sm",
+    );
+
+    expect(Spinner).toHaveBeenCalled();
+    expect(Spinner.mock.calls[0][0]).toEqual({ size: "large" });
+  });
+});

--- a/src/__tests__/appTest/not-found.test.js
+++ b/src/__tests__/appTest/not-found.test.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import NotFound from "@/app/not-found";
+import Button from "@/components/Button/Button";
+
+jest.mock("@/context/LanguageContext", () => ({
+  useLanguage: () => ({
+    translations: {
+      "notFound.title": "Page not found",
+      "notFound.message":
+        "Sorry, the page you are looking for doesn't exist or has been moved.",
+      "notFound.button": "Back to home",
+    },
+  }),
+}));
+
+jest.mock("@/components/Button/Button", () => {
+  return jest.fn((props) => (
+    <button data-testid="button-mock">{props.text}</button>
+  ));
+});
+
+describe("NotFound", () => {
+  it("should render the not found page with correct translations", () => {
+    render(<NotFound />);
+
+    expect(screen.getByText("Page not found")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Sorry, the page you are looking for doesn't exist or has been moved.",
+      ),
+    ).toBeInTheDocument();
+
+    expect(Button).toHaveBeenCalled();
+
+    const buttonProps = Button.mock.calls[0][0];
+    expect(buttonProps.text).toBe("Back to home");
+    expect(buttonProps.variant).toBe("redFullText");
+    expect(buttonProps.linkUrl).toBe("/");
+    expect(buttonProps["aria-label"]).toBe("Back to home");
+  });
+});

--- a/src/app/loading.js
+++ b/src/app/loading.js
@@ -1,0 +1,10 @@
+import React from "react";
+import Spinner from "@/components/UI/Spinner";
+
+export default function RootLoading() {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/80 backdrop-blur-sm">
+      <Spinner size="large" />
+    </div>
+  );
+}

--- a/src/app/not-found.js
+++ b/src/app/not-found.js
@@ -1,0 +1,29 @@
+"use client";
+
+import React from "react";
+import { useLanguage } from "@/context/LanguageContext";
+
+import Button from "@/components/Button/Button";
+
+export default function NotFound() {
+  const { translations } = useLanguage();
+
+  return (
+    <div className="custom-services-banner flex min-h-[50vh] flex-col items-center justify-center px-4 text-center">
+      <h1 className="mb-4 text-headlineMedium text-tertiary1-darker md:text-headlineLarge">
+        {translations["notFound.title"]}
+      </h1>
+      <p className="mb-8 max-w-md text-bodyMedium text-tertiary1-normal md:text-bodyLarge">
+        {translations["notFound.message"]}
+      </p>
+      <div>
+        <Button
+          text={translations["notFound.button"]}
+          variant="redFullText"
+          linkUrl="/"
+          aria-label={translations["notFound.button"]}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.js
+++ b/src/app/not-found.js
@@ -1,8 +1,6 @@
 "use client";
-
 import React from "react";
 import { useLanguage } from "@/context/LanguageContext";
-
 import Button from "@/components/Button/Button";
 
 export default function NotFound() {

--- a/src/components/UI/Spinner.js
+++ b/src/components/UI/Spinner.js
@@ -1,0 +1,18 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export default function Spinner({ size = "medium" }) {
+  const sizeClasses = {
+    small: "h-6 w-6",
+    medium: "h-10 w-10",
+    large: "h-12 w-12",
+  };
+
+  const spinnerClass = `${sizeClasses[size] || sizeClasses.medium} animate-spin rounded-full border-4 border-primary-normal border-t-transparent`;
+
+  return <div className={spinnerClass}></div>;
+}
+
+Spinner.propTypes = {
+  size: PropTypes.string,
+};

--- a/src/translations/dk.json
+++ b/src/translations/dk.json
@@ -248,5 +248,8 @@
   "sales.complaints.li1": "E-mail",
   "sales.complaints.li2": "Telefon",
   "sales.complaints.p2": "Vi bestræber os på at besvare alle henvendelser inden for 2 hverdage.",
-  "sales.footer": "Disse oplysninger gives i overensstemmelse med Forbrugerombudsmandens krav til brug af MobilePay og sikrer gennemsigtighed for vores værdsatte kunder."
+  "sales.footer": "Disse oplysninger gives i overensstemmelse med Forbrugerombudsmandens krav til brug af MobilePay og sikrer gennemsigtighed for vores værdsatte kunder.",
+  "notFound.title": "Siden blev ikke fundet",
+  "notFound.message": "Beklager, siden du leder efter findes ikke eller er blevet flyttet.",
+  "notFound.button": "Tilbage til forsiden"
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -249,5 +249,8 @@
   "sales.complaints.li1": "Email",
   "sales.complaints.li2": "Phone",
   "sales.complaints.p2": "We aim to respond to all inquiries within 2 business days.",
-  "sales.footer": "This information is provided in compliance with the Consumer Ombudsman’s requirements for use of MobilePay and ensures transparency for our valued customers."
+  "sales.footer": "This information is provided in compliance with the Consumer Ombudsman’s requirements for use of MobilePay and ensures transparency for our valued customers.",
+  "notFound.title": "Page not found",
+  "notFound.message": "Sorry, the page you are looking for doesn't exist or has been moved.",
+  "notFound.button": "Back to home"
 }


### PR DESCRIPTION
# [FEATURE] Improve Navigation Feedback with Loading States and Not-Found Pages

## Description
This PR enhances the user experience by adding visual feedback during page transitions and standardised error handling for not-found routes. It addresses the issue where users receive no feedback when clicking navigation links, making it unclear if the app is processing their request.

**Problem solved:** Users currently experience silent page transitions with no loading indicators, causing uncertainty and potential double-clicks
**Impact:** Provides immediate visual feedback during navigation, reducing user confusion and creating a more polished experience

## Changes Made
**UI Components:**
- Created reusable `Spinner` component with customizable size options
- Added root-level `loading.js` for site-wide navigation feedback
- Added global `not-found.js` page for standardised 404 error handling

**Localization:**
- Added translations for not-found page content in both English and Danish

**Tests:**
- Added tests for newly created pages.

## Screenshots

https://github.com/user-attachments/assets/72e09c5d-5010-43f9-bf6a-192d78e6ab33

<img src="https://github.com/user-attachments/assets/233c9ed8-36a1-49e7-9c34-ff5974dd113d" width="600" /> 
<img src="https://github.com/user-attachments/assets/5aa6412a-f685-4901-aac5-8c2846065b84" width="200" /> 

## Testing Steps
Setup: No special setup required

Steps:
- Navigate between different sections of the application
- Observe loading indicators during transitions
- Try accessing a non-existent route (e.g., /this-page-does-not-exist)

Expected Result:
- During navigation, a spinner with backdrop overlay should briefly appear
- For non-existent routes, the styled not-found page should display with proper translations

## Issues Addressed
Closes [#195 Improve Navigation Feedback with Loading States and Not-Found Page](https://github.com/Donna-Vino-Aps/donna-vino-ecommerce/issues/195)

## Additional Notes
We can change the design of Spinner and the not-found page easily later, when the design team develop this. 