### PR TITLE
[FIX] Stabilise Event View Layout and Prevent UI Jumps

### DIFF
--- a/src/app/events/page.js
+++ b/src/app/events/page.js
@@ -20,7 +20,7 @@ const Events = () => {
         <EventContent>
           {({ processedEvents }) => (
             <>
-              <section className="mx-8 mb-8 flex flex-col justify-center gap-8 xl:mb-12 xl:flex-row xl:gap-12">
+              <section className="mx-8 mb-8 flex flex-col justify-center gap-8 xl:mx-1 xl:mb-12 xl:flex-row xl:gap-2 2xl:gap-12">
                 <SEO
                   title={translations["events.title"]}
                   description={translations["events.description"]}

--- a/src/components/Events/EventList.js
+++ b/src/components/Events/EventList.js
@@ -37,7 +37,7 @@ const EventList = ({ events, onEventClick }) => {
       return (
         <div
           className={`flex flex-col items-center ${
-            isMobile ? "" : "mx-auto sm:min-w-[34rem] xl:mx-0"
+            isMobile ? "" : "mx-auto sm:min-w-[40.2rem] xl:mx-0"
           }`}
         >
           {!isMobile && <MonthHeader />}
@@ -99,7 +99,7 @@ const EventList = ({ events, onEventClick }) => {
     }
 
     return (
-      <div className="mx-auto flex flex-col overflow-hidden sm:min-w-[34rem] xl:mx-0 xl:h-[31rem]">
+      <div className="mx-auto flex flex-col overflow-hidden sm:min-w-[40.2rem] xl:mx-0 xl:h-[31rem]">
         <MonthHeader />
 
         <div className="flex flex-row gap-2 rounded-t bg-tertiary2-active p-3 pb-7 text-titleMedium font-medium text-tertiary1-active_dark">

--- a/src/components/Events/EventMobileView.js
+++ b/src/components/Events/EventMobileView.js
@@ -30,7 +30,7 @@ const EventMobileView = ({
 
   return (
     <div
-      className={`min-h-[8rem] border-b-[1px] border-l-4 bg-tertiary2-active sm:min-h-[7.9rem] ${seatStatus.borderColor} border-b-tertiary1-hover`}
+      className={`min-h-[8.5rem] border-b-[1px] border-l-4 bg-tertiary2-active ${seatStatus.borderColor} border-b-tertiary1-hover sm:min-h-[9rem]`}
     >
       {activeView === "date" && (
         <div


### PR DESCRIPTION
# [FIX] Stabilise Event View Layout and Prevent UI Jumps
## Description
This pull request addresses two visual bugs in the events page that were causing layout shifts and a jarring user experience.

**What problem does this PR solve?**
- When switching between "Date" and "Event details" tabs in the mobile view, the container would "jump" because the tabs had different heights. 	
- When navigating between months in the desktop view, the container's width would change, causing the entire component to shift horizontally. 

**What is the impact of the change?**
The changes result in a more stable, fluid, and predictable user interface. By enforcing consistent minimum dimensions, the layout no longer shifts during user interactions, leading to a better overall user experience.

## Changes Made
- Styling:
   - ⁠`EventMobileView.js`: Increased the ⁠min-height for the mobile event item. This normalises the height across different tabs, eliminating the vertical "jump" when switching between them. 
   - `EventList.js`: Increased the ⁠minimum width for the event list container. This ensures the container maintains a consistent width, even if the content for a specific month is narrower, preventing the horizontal layout shift. 
   - `events/page.js`: Adjusted horizontal margins and gaps on ⁠xl screens to better accommodate the new minimum width of the child components and improve overall layout alignment.

## Screenshots


https://github.com/user-attachments/assets/0f441caf-b24e-45af-87bc-dbbfbec412cf


https://github.com/user-attachments/assets/8e42783a-5cf7-4e41-8534-dffa6175ff00


## Testing Steps

1. Setup:
- Pull the branch locally or checkout the deployed version.

2. Steps to Verify Height Fix (Tab Jumping):
- Navigate to the ⁠/events page on a mobile screen size. 
- Find an event and toggle between the "Date" and "Event details" view tabs. 	
Expected Result: The page content should remain stable without any vertical jumping or layout shifts. 	

3. Steps to Verify Width Fix (Month Shifting):
- Navigate to the ⁠/events page on a desktop screen size (larger than ⁠sm). 	
- Use the arrow buttons to navigate back and forth between different months. 
Expected Result: The event list container should maintain its width and position, and the surrounding layout should not shift horizontally.