### PR TITLE
feat: layout update, add real links and use Link for routing

### DIFF
--- a/src/components/HeroSlider/HeroSlider.js
+++ b/src/components/HeroSlider/HeroSlider.js
@@ -1,7 +1,9 @@
 "use client";
+
 import React, { useState, useRef } from "react";
 import Button from "../Button/Button";
 import dynamic from "next/dynamic";
+
 const SwiperClient = dynamic(() => import("../Swiper/SwiperClient"), {});
 import { SwiperSlide } from "swiper/react";
 import ComingSoonModal from "../Modal/ComingSoonModal";
@@ -12,7 +14,7 @@ const HeroSlider = () => {
   const { translations } = useLanguage();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const hasCredits = false;
-  const swiperRef = useRef();
+  const swiperRef = useRef(null);
 
   const slides = [
     {
@@ -134,27 +136,31 @@ const HeroSlider = () => {
                   </div>
                 )}
               </div>
-              <div className="flex h-[22.5rem] w-full flex-col justify-center px-6 text-center font-barlow font-regular md:max-w-[50%] md:items-start md:px-6 lg:px-10 xl:px-14">
-                <div>
-                  <p className="text-left text-headlineSmall text-primary-normal">
-                    {translations[slide.subheading]}
+              <div className="flex h-[22.5rem] w-full flex-col justify-between px-6 md:max-w-[50%] md:items-start md:px-6 lg:px-10 xl:px-14">
+                <div className="flex min-h-[43.75rem] flex-col justify-center text-center font-barlow font-regular">
+                  <div>
+                    <p className="text-left text-headlineSmall text-primary-normal">
+                      {translations[slide.subheading]}
+                    </p>
+                  </div>
+                  <h2 className="my-4 mr-8 text-left text-displayMedium text-tertiary1-dark md:my-2 md:text-left md:text-headlineLarge lg:text-displaySmall xl:text-displayMedium">
+                    {translations[slide.heading]}
+                  </h2>
+                  <p className="mb-4 mr-10 mt-2 text-start text-bodyMedium sm:mb-7 sm:mt-2 md:mb-5 md:mt-2 md:text-start md:text-bodyMedium xl:mb-10 xl:text-bodyLarge">
+                    {translations[slide.paragraph]}
                   </p>
+                  <Button
+                    text={translations[slide.buttonText]}
+                    icon={slide.buttonIcon}
+                    width="wide"
+                    aria-label={translations[slide.buttonText]}
+                    data-testid="book-tasting-button"
+                    linkUrl={slide.url}
+                    onClick={
+                      index === 1 ? () => setIsModalOpen(true) : undefined
+                    }
+                  />
                 </div>
-                <h2 className="my-4 mr-8 text-left text-displayMedium text-tertiary1-dark md:my-2 md:text-left md:text-headlineLarge lg:text-displaySmall xl:text-displayMedium">
-                  {translations[slide.heading]}
-                </h2>
-                <p className="mb-4 mr-10 mt-2 text-start text-bodyMedium sm:mb-7 sm:mt-2 md:mb-5 md:mt-2 md:text-start md:text-bodyMedium xl:mb-10 xl:text-bodyLarge">
-                  {translations[slide.paragraph]}
-                </p>
-                <Button
-                  text={translations[slide.buttonText]}
-                  icon={slide.buttonIcon}
-                  width="wide"
-                  aria-label={translations[slide.buttonText]}
-                  data-testid="book-tasting-button"
-                  linkUrl={slide.url}
-                  onClick={index === 1 ? () => setIsModalOpen(true) : undefined}
-                ></Button>
                 <div
                   className={`mt-4 hidden md:absolute md:bottom-8 md:flex lg:bottom-10 xl:bottom-14 ${index === 0 ? "md:right-8 lg:right-10 xl:right-12" : "md:left-[37.5%]"}`}
                 >

--- a/src/components/ServicesBanner/ServicesBanner.js
+++ b/src/components/ServicesBanner/ServicesBanner.js
@@ -1,35 +1,36 @@
+"use client";
+
 import React from "react";
 import { useLanguage } from "@/context/LanguageContext";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 
 const services = [
   {
     icon: "/icons/services-icon1.svg",
     altKey: "services.p1",
-    linkTestId: "webshop-link",
+    linkTestId: "/wines/pre-sale",
     className:
       "relative flex flex-col items-center justify-center gap-x-2 gap-y-4 text-tertiary1-darker md:left-2 md:ml-4 md:flex-row lg:left-1 lg:ml-5 xl:left-6 xl:gap-x-4",
   },
   {
     icon: "/icons/services-icon2.svg",
     altKey: "services.p2",
-    linkTestId: "delivery-link",
+    linkTestId: "/sales-policy#shipping",
     className:
       "flex flex-col items-center justify-center gap-x-4 gap-y-4 text-tertiary1-darker md:flex-row",
   },
   {
     icon: "/icons/services-icon3.svg",
     altKey: "services.p3",
-    linkTestId: "events-link",
+    linkTestId: "/events",
     className:
       "relative flex flex-col items-center justify-center gap-x-4 gap-y-4 text-tertiary1-darker md:right-2 md:mr-4 md:flex-row lg:right-1 lg:mr-5 xl:right-6",
   },
 ];
 
 const ServicesBanner = () => {
-  const router = useRouter();
   const { translations } = useLanguage();
+
   return (
     <div className="custom-services-banner flex w-full flex-col items-center justify-center gap-y-8 px-5 py-8 md:min-h-[20rem] md:py-20">
       <h1 className="text-center text-headlineLarge text-tertiary1-darker md:text-displaySmall">
@@ -37,22 +38,22 @@ const ServicesBanner = () => {
       </h1>
       <section className="flex w-full flex-col justify-around space-y-4 text-titleLarge md:flex-row md:text-titleMedium lg:text-titleLarge">
         {services.map((service, index) => (
-          <article key={index} className={service.className}>
+          <Link
+            key={index}
+            className={service.className}
+            aria-label={translations[service.altKey]}
+            data-testid={service.linkTestId}
+            href={service.linkTestId}
+          >
             <img
               src={service.icon}
               alt={translations["services.p3"]}
               className="h-[5rem] cursor-pointer md:h-[4.25rem] lg:h-[5rem]"
-              onClick={() => router.push("/")}
-            ></img>
-            <Link
-              href=""
-              data-testid={service.linkTestId}
-              aria-label={translations[service.altKey]}
-              className="max-w-[15rem] text-center font-barlow font-normal md:max-w-[9rem] md:text-left lg:max-w-[13rem]"
-            >
+            />
+            <span className="max-w-[15rem] text-center font-barlow font-normal md:max-w-[9rem] md:text-left lg:max-w-[13rem]">
               {translations[service.altKey]}
-            </Link>
-          </article>
+            </span>
+          </Link>
         ))}
       </section>
     </div>


### PR DESCRIPTION
[FEATURE] Add links to `ServicesBanner` and center content in `HeroSlider`

## Description

This PR improves routing and layout in two separate components:
• Adds real navigational links to `ServicesBanner`
• Centers the main content block within `HeroSlider`

## Changes Made

- **UI Components:**
`ServicesBanner`:
• Replaced onClick with semantic <Link> components for better accessibility and client-side navigation.
• Inserted real URLs for each service item.
• Improved markup structure for clarity and testability (data-testid, aria-label).

`HeroSlider`:
• Centered the main content block vertically.

## Screenshots

![Screenshot 2025-07-08 at 12 43 26](https://github.com/user-attachments/assets/b049f687-af7c-45af-8fc1-c64c652e5bfc)

## Testing Steps

1. Run the app locally (npm run dev)

2. Test `ServicesBanner`:
• Verify each service block is wrapped in a working <Link> element
• Clicking a link routes to the correct URL

3. Test HeroSlider:
• Check that the main content block appears vertically centered