### PR TITLE
fix:add margin top for dropdown

### DIFF
--- a/src/components/WineDetails/MoreInformationDropdown.js
+++ b/src/components/WineDetails/MoreInformationDropdown.js
@@ -42,7 +42,7 @@ const MoreInfoDropdown = ({ wine }) => {
   ];
 
   return (
-    <article className=" w-full ">
+    <article className="mt-32 w-full">
       <div
         className={`mx-auto my-4 w-11/12 min-w-[270px] max-w-[1250px] ${!isMobile && "rounded-b-lg"} ${isOpen && !isMobile && "shadow-md"}`}
       >


### PR DESCRIPTION
# Pull Request Title

[Fix] Margin top for moreInfoDropdown 

## Description

I missed space above moreInfoDropdown so in this PR I just quickly fix that.
- What problem does this PR solve? Previously moreInfoDropdown did not align with Figma styles.
- What is the impact of the change? Now it seems like we have ready product page that aligns with Figma design.

## Changes Made


- **Styling:** Added margin top for moreInfoDropdown

## Screenshots (if applicable)

Before:
<img width="1466" alt="Screenshot 2025-07-09 at 07 21 43" src="https://github.com/user-attachments/assets/3fa7ad23-f402-42a2-ae7c-ba711bfa8c8b" />
Now:
<img width="1367" alt="Screenshot 2025-07-09 at 07 21 59" src="https://github.com/user-attachments/assets/cc2d6630-db5c-4568-98ad-80f018a8cec9" />

## Testing Steps

Explain how reviewers can test this PR locally.

**Steps:** 
1. Use deployment link
2. Open any product page
3. Notice better spacing 
**Expected Result:**Now whole page is ready and alignes with Figma styles.

## Issues Addressed

Halyna noticed issue with layout related to this moreInfoCompponent.

## Additional Notes

This is just short fix.
