### PR TITLE
Feat/snackbar

### DIFF
--- a/src/components/Cart/CartModalMobile.js
+++ b/src/components/Cart/CartModalMobile.js
@@ -1,0 +1,56 @@
+"use client";
+
+import React from "react";
+import { useLanguage } from "@/context/LanguageContext";
+import Image from "next/image";
+import PropTypes from "prop-types";
+
+export default function CartModalMobile({ wine, isOpen }) {
+  const { translations } = useLanguage();
+
+  if (!isOpen) return null;
+
+  return (
+    <section className="fixed right-0 top-0 flex h-[16rem] w-full flex-col items-center justify-between rounded-lg bg-white p-6 shadow-lg">
+      <div>
+        <p className="font-barlow text-headlineSmall text-tertiary1-darker">
+          {translations["wineCard.addedToCart"]}
+        </p>
+      </div>
+      <div className="flex h-32 w-full items-center gap-2 self-stretch rounded-md border border-primary-normal bg-tertiary2-light px-4 shadow-sm">
+        <div>
+          <Image
+            src={wine.imageUrl}
+            alt={wine.title}
+            width={100}
+            height={110}
+          />
+        </div>
+        <div className="flex h-32 w-full flex-col justify-between p-4 text-titleSmall text-tertiary1-darker">
+          <div>
+            <div>{wine.title}</div>
+            <div className="text-labelSmall">{wine.vintage}</div>
+          </div>
+          <div className="flex justify-between">
+            <div>
+              {wine.quantity} {translations[`wine-details.${wine.size}`]}
+            </div>
+            <div>{wine.totalPrice} kr</div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+CartModalMobile.propTypes = {
+  wine: PropTypes.shape({
+    imageUrl: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    vintage: PropTypes.string,
+    quantity: PropTypes.number.isRequired,
+    totalPrice: PropTypes.number.isRequired,
+    size: PropTypes.string.isRequired,
+  }).isRequired,
+  isOpen: PropTypes.bool.isRequired,
+};

--- a/src/components/Cart/WineAddedPopup.js
+++ b/src/components/Cart/WineAddedPopup.js
@@ -5,19 +5,19 @@ import { useLanguage } from "@/context/LanguageContext";
 import Image from "next/image";
 import PropTypes from "prop-types";
 
-export default function CartModalMobile({ wine, isOpen }) {
+export default function WineAddedPopup({ wine, isOpen }) {
   const { translations } = useLanguage();
 
   if (!isOpen) return null;
 
   return (
-    <section className="fixed right-0 top-0 flex h-[16rem] w-full flex-col items-center justify-between rounded-lg bg-white p-6 shadow-lg">
+    <section className="fixed top-0 z-50 flex h-[16rem] w-full flex-col items-center justify-between rounded-lg bg-tertiary2-light p-6 shadow-lg transition-opacity duration-300 md:right-0 md:top-0 md:w-[24rem]">
       <div>
         <p className="font-barlow text-headlineSmall text-tertiary1-darker">
-          {translations["wineCard.addedToCart"]}
+          {translations["wineCard.addedToYourCart"]}
         </p>
       </div>
-      <div className="flex h-32 w-full items-center gap-2 self-stretch rounded-md border border-primary-normal bg-tertiary2-light px-4 shadow-sm">
+      <div className="flex h-32 w-full items-center gap-2 self-stretch rounded-md border border-primary-normal bg-tertiary2-light px-4 shadow-card">
         <div>
           <Image
             src={wine.imageUrl}
@@ -43,7 +43,7 @@ export default function CartModalMobile({ wine, isOpen }) {
   );
 }
 
-CartModalMobile.propTypes = {
+WineAddedPopup.propTypes = {
   wine: PropTypes.shape({
     imageUrl: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,

--- a/src/components/Cart/WineAddedPopup.js
+++ b/src/components/Cart/WineAddedPopup.js
@@ -11,7 +11,7 @@ export default function WineAddedPopup({ wine, isOpen }) {
   if (!isOpen) return null;
 
   return (
-    <section className="fixed top-0 z-50 flex h-[16rem] w-full flex-col items-center justify-between rounded-lg bg-tertiary2-light p-6 shadow-lg transition-opacity duration-300 md:right-0 md:top-0 md:w-[24rem]">
+    <section className="fixed top-0 z-50 flex h-[16rem] w-full flex-col items-center justify-between rounded-lg bg-tertiary2-light p-6 shadow-lg transition-opacity duration-300 lg:right-0 lg:top-0 lg:w-[24rem]">
       <div>
         <p className="font-barlow text-headlineSmall text-tertiary1-darker">
           {translations["wineCard.addedToYourCart"]}

--- a/src/components/TasteProfile/TasteProfilePercentage.js
+++ b/src/components/TasteProfile/TasteProfilePercentage.js
@@ -20,13 +20,6 @@ export default function TasteProfilePercentage({ wine }) {
               className="absolute inset-y-0 left-0 rounded-full bg-primary-active_dark"
               style={{ width: `${pair.value}%` }}
             ></div>
-            <div
-              className="absolute -top-9 -translate-x-1/2 transform rounded-md bg-primary-active_dark px-3 py-1 text-labelSmall text-tertiary2-light md:text-labelLarge"
-              style={{ left: `${pair.value}%` }}
-            >
-              {pair.value}%
-              <div className="absolute -bottom-1 left-1/2 h-0 w-0 -translate-x-1/2 border-x-4 border-t-4 border-x-transparent border-t-primary-active_dark"></div>
-            </div>
           </div>
           <div className="flex justify-between text-bodyMedium">
             <span className="w-20 shrink-0 text-left text-bodySmall md:text-bodyMedium">

--- a/src/components/WineDetails/WineInfo.js
+++ b/src/components/WineDetails/WineInfo.js
@@ -13,10 +13,13 @@ import Image from "next/image";
 import { logError } from "@/utils/logging";
 import AnimatedButton from "../Button/AnimatedButton";
 import CartModal from "@/components/Cart/CartModal";
+import CartModalMobile from "@/components/Cart/CartModalMobile";
+import useIsMobile from "@/hooks/useIsMobile";
 
 const WineInfo = ({ wine }) => {
   const { translations } = useLanguage();
   const { addItemToCart } = useCart();
+  const isMobile = useIsMobile();
 
   const [showCart, setShowCart] = useState(false);
   const [selectedSize, setSelectedSize] = useState(() => {
@@ -26,7 +29,7 @@ const WineInfo = ({ wine }) => {
   });
 
   const [preSale, setPreSale] = useState(!wine.inStock);
-  const [selectedQuantity, setSelectedQuantity] = React.useState(1);
+  const [selectedQuantity, setSelectedQuantity] = useState(1);
 
   const handleAddToCart = () => {
     const selectedVariant = wine.variantMap[selectedSize];
@@ -148,7 +151,22 @@ const WineInfo = ({ wine }) => {
           grape={wine.grape}
         />
       </div>
-      <CartModal isOpen={showCart} onClose={() => setShowCart(false)} />
+      {isMobile ? (
+        <CartModalMobile
+          isOpen={showCart}
+          wine={{
+            imageUrl: wine.imageUrl,
+            title: wine.title,
+            vintage: wine.vintage,
+            size: selectedSize,
+            quantity: selectedQuantity,
+            totalPrice:
+              wine.variantMap[selectedSize].price.amount * selectedQuantity,
+          }}
+        />
+      ) : (
+        <CartModal isOpen={showCart} onClose={() => setShowCart(false)} />
+      )}
     </article>
   );
 };
@@ -174,6 +192,7 @@ WineInfo.propTypes = {
     region: PropTypes.string.isRequired,
     vineyard: PropTypes.string.isRequired,
     wineVariety: PropTypes.string.isRequired,
+    vintage: PropTypes.string,
     grape: PropTypes.string.isRequired,
     variantMap: PropTypes.shape({
       bottle: PropTypes.object,

--- a/src/components/WineDetails/WineInfo.js
+++ b/src/components/WineDetails/WineInfo.js
@@ -1,4 +1,5 @@
 "use client";
+
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { AvailabilityDisplay } from "./AvailabilityDisplay";
@@ -11,11 +12,13 @@ import { useCart } from "@/context/ShoppingCartContext";
 import Image from "next/image";
 import { logError } from "@/utils/logging";
 import AnimatedButton from "../Button/AnimatedButton";
+import CartModal from "@/components/Cart/CartModal";
 
 const WineInfo = ({ wine }) => {
   const { translations } = useLanguage();
   const { addItemToCart } = useCart();
 
+  const [showCart, setShowCart] = useState(false);
   const [selectedSize, setSelectedSize] = useState(() => {
     if (wine.variantMap.bottle) return "bottle";
     if (wine.variantMap.case) return "case";
@@ -45,6 +48,8 @@ const WineInfo = ({ wine }) => {
       imageUrl: wine.imageUrl,
     };
     addItemToCart(itemToAdd);
+    setShowCart(true);
+    setTimeout(() => setShowCart(false), 3000);
   };
 
   return (
@@ -143,6 +148,7 @@ const WineInfo = ({ wine }) => {
           grape={wine.grape}
         />
       </div>
+      <CartModal isOpen={showCart} onClose={() => setShowCart(false)} />
     </article>
   );
 };

--- a/src/components/WineDetails/WineInfo.js
+++ b/src/components/WineDetails/WineInfo.js
@@ -12,16 +12,13 @@ import { useCart } from "@/context/ShoppingCartContext";
 import Image from "next/image";
 import { logError } from "@/utils/logging";
 import AnimatedButton from "../Button/AnimatedButton";
-import CartModal from "@/components/Cart/CartModal";
-import CartModalMobile from "@/components/Cart/CartModalMobile";
-import useIsMobile from "@/hooks/useIsMobile";
+import WineAddedPopup from "@/components/Cart/WineAddedPopup";
 
 const WineInfo = ({ wine }) => {
   const { translations } = useLanguage();
   const { addItemToCart } = useCart();
-  const isMobile = useIsMobile();
 
-  const [showCart, setShowCart] = useState(false);
+  const [showPopup, setShowPopup] = useState(false);
   const [selectedSize, setSelectedSize] = useState(() => {
     if (wine.variantMap.bottle) return "bottle";
     if (wine.variantMap.case) return "case";
@@ -51,12 +48,12 @@ const WineInfo = ({ wine }) => {
       imageUrl: wine.imageUrl,
     };
     addItemToCart(itemToAdd);
-    setShowCart(true);
-    setTimeout(() => setShowCart(false), 3000);
+    setShowPopup(true);
+    setTimeout(() => setShowPopup(false), 3000);
   };
 
   return (
-    <article className="relative flex flex-col items-center justify-center gap-6 md:gap-8 lg:flex-row lg:gap-12">
+    <div className="relative flex flex-col items-center justify-center gap-6 md:gap-8 lg:flex-row lg:gap-12">
       <Image
         src={wine.imageUrl}
         alt={wine.title}
@@ -151,23 +148,19 @@ const WineInfo = ({ wine }) => {
           grape={wine.grape}
         />
       </div>
-      {isMobile ? (
-        <CartModalMobile
-          isOpen={showCart}
-          wine={{
-            imageUrl: wine.imageUrl,
-            title: wine.title,
-            vintage: wine.vintage,
-            size: selectedSize,
-            quantity: selectedQuantity,
-            totalPrice:
-              wine.variantMap[selectedSize].price.amount * selectedQuantity,
-          }}
-        />
-      ) : (
-        <CartModal isOpen={showCart} onClose={() => setShowCart(false)} />
-      )}
-    </article>
+      <WineAddedPopup
+        isOpen={showPopup}
+        wine={{
+          imageUrl: wine.imageUrl,
+          title: wine.title,
+          vintage: wine.vintage,
+          size: String(selectedSize),
+          quantity: selectedQuantity,
+          totalPrice:
+            wine.variantMap[selectedSize].price.amount * selectedQuantity,
+        }}
+      />
+    </div>
   );
 };
 

--- a/src/hooks/useIsMobile.js
+++ b/src/hooks/useIsMobile.js
@@ -3,9 +3,7 @@
 import { useState, useEffect } from "react";
 
 export function useIsMobile(breakpoint = 768) {
-  const [isMobile, setIsMobile] = useState(
-    typeof window !== "undefined" && window.innerWidth < breakpoint,
-  );
+  const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") return;

--- a/src/translations/dk.json
+++ b/src/translations/dk.json
@@ -341,6 +341,7 @@
   "wineCard.viewDetails": "Se detaljer",
   "wineCard.addToCart": "Læg i indkøbskurv",
   "wineCard.addedToCart": "Tilføjet til kurven!",
+  "wineCard.addedToYourCart": "Tilføjet til din kurv!",
   "presale.no-wine-matches-filter": "Ingen forsalgs-vine matcher dine filtre.",
   "presale.no-wine": "Ingen forsalgs-vine tilgængelige i øjeblikket.",
   "presale-filter.wineVariety": "Vintype",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -342,7 +342,7 @@
   "cart.case": "Case (6 bottles)",
   "wineCard.viewDetails": "View details",
   "wineCard.addToCart": "Add to cart",
-  "wineCard.addedToCart": "Added to cart",
+  "wineCard.addedToCart": "Added to cart!",
   "presale.no-wine-matches-filter": "No pre-sale wines match your filters.",
   "presale.no-wine": "No pre-sale wines available at the moment.",
   "presale-filter.wineVariety": "Wine Type",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -343,6 +343,7 @@
   "wineCard.viewDetails": "View details",
   "wineCard.addToCart": "Add to cart",
   "wineCard.addedToCart": "Added to cart!",
+  "wineCard.addedToYourCart": "Added to your cart!",
   "presale.no-wine-matches-filter": "No pre-sale wines match your filters.",
   "presale.no-wine": "No pre-sale wines available at the moment.",
   "presale-filter.wineVariety": "Wine Type",

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -139,6 +139,9 @@ export default {
         "dots-size-lg": "35px 35px",
         "dots-size-sm": "25px 25px",
       },
+      boxShadow: {
+        card: '0 1px 4px 0 rgba(0, 0, 0, 0.25)',
+      },
     },
   },
   darkMode: "class", // Enable dark mode using a class


### PR DESCRIPTION
# [FEATURE] Add mobile cart modal and show desktop cart for 3 seconds on add

## Description

This PR introduces a new cart popup that is used across all screen sizes for consistency:
• A modal appears at the top of the screen for 3 seconds after a wine is added to the cart. It shows the wine image, title, vintage, selected size (bottle/case), quantity, and total price.
• Also removed percentage icons from the `TasteProfile.js` component.

## Changes Made

### UI Components

• Created and added `WineAddedPopup` component.
• Updated `WineInfo` component to show the cart modal based on screen size.
•  Improve `useIsMobile` to avoid hydration issues.

## Screenshots (if applicable)

<img width="1438" height="658" alt="Screenshot 2025-08-05 at 10 59 14" src="https://github.com/user-attachments/assets/407720f3-7eda-4dc4-92a2-776613855d3d" />
<img width="527" height="659" alt="Screenshot 2025-08-05 at 11 07 17" src="https://github.com/user-attachments/assets/aaee8fec-616b-407f-9358-a69f201487b7" />
<img width="1410" height="489" alt="Screenshot 2025-07-30 at 18 39 10" src="https://github.com/user-attachments/assets/3a4890ec-8267-4b92-83ff-6c40bb499ee7" />

## Testing Steps

1.	Go to a wine product page
2.	Select a size and quantity
3.	Click “Add Pre-Order to Cart”
4.	✅ On mobile (<768px):
• A modal appears at the top of the screen for 3 seconds
5.	✅ On desktop (≥768px):
• A modal appears at the right side of the screen for 3 seconds
6.	✅ Check that Taste Profile no longer shows percentage icons