### PR TITLE
Importing Tastecards Data

### DIFF
--- a/src/__tests__/libTest/shopify/transformers.test.js
+++ b/src/__tests__/libTest/shopify/transformers.test.js
@@ -162,6 +162,15 @@ const mockShopifyWineProductSpecific = {
   tasteProfile: {
     value: '[\"Nuanced\",\"Spicy\",\"Fruity\",\"Berries\",\"Acidic\"]',
   },
+  tastesFruits: {
+    value: '[\"Pineapple\",\"mango\",\"passion fruit\"]',
+  },
+  tastesSpices: {
+    value: '[\"Black pepper\",\"cloves\",\"thyme\"]',
+  },
+  tastesNotes: {
+    value: '[\"Truffles\",\"undergrowth\",\"mushrooms\"]',
+  },
   alcoholContent: {
     value: "13.5",
   },
@@ -359,6 +368,9 @@ describe("Shopify Data Transformers", () => {
         grape: "Pinot noir",
         vineyard: "Cantina Kurtatsch",
         tasteProfile: ["Nuanced", "Spicy", "Fruity", "Berries", "Acidic"],
+        tastesFruits: ["Pineapple", "mango", "passion fruit"],
+        tastesSpices: ["Black pepper", "cloves", "thyme"],
+        tastesNotes: ["Truffles", "undergrowth", "mushrooms"],
         alcoholContent: 13.5,
         servingTemperature: "16-18",
         vintage: "2024",

--- a/src/graphql/fragments/wineProduct.js
+++ b/src/graphql/fragments/wineProduct.js
@@ -69,6 +69,15 @@ const wineProductFragment = `
     tasteProfile: metafield(namespace: "wine", key: "taste_profile") {
       value
     }
+    tastesFruits: metafield(namespace: "wine", key: "tastes_fruits") {
+      value
+    }
+    tastesSpices: metafield(namespace: "wine", key: "tastes_spices") {
+      value
+    }
+    tastesNotes: metafield(namespace: "wine", key: "tastes_notes") {
+      value
+    }  
     alcoholContent: metafield(namespace: "wine", key: "alcohol_content") {
       value
     }

--- a/src/lib/shopify/transformers.js
+++ b/src/lib/shopify/transformers.js
@@ -169,6 +169,14 @@ export function transformShopifyWineProduct(product) {
     tasteProfile:
       parseJsonMetafield(product.tasteProfile, "tasteProfile", product.id) ||
       [],
+    tastesFruits:
+      parseJsonMetafield(product.tastesFruits, "tastesFruits", product.id) ||
+      [],
+    tastesSpices:
+      parseJsonMetafield(product.tastesSpices, "tastesSpices", product.id) ||
+      [],
+    tastesNotes:
+      parseJsonMetafield(product.tastesNotes, "tastesNotes", product.id) || [],
     volume: parseJsonMetafield(product.volume, "volume", product.id),
 
     // Parsed numeric metafields


### PR DESCRIPTION
# Importing Tastecards Data

## Description

- What problem does this PR solve? Before, the data from shopify didnt include any fields related to the tasteCards. Now 3 fields are added and fetched from shopify into our project so that they can be displayed in the component.
- What is the impact of the change? TasteCards now have real data that is dynamically fetched from shopify.

## Changes Made

1. I added three single line text list metafields in shopify (and filled these with some example data, that will be changed later by Katrine
2. I updated the graphQL query and the transformer-function to include these 3 fields
3. I updated the tests to reflect these changes

## Screenshots (if applicable)

These are the tasteCards (and some changes we decided to make in order to make the rendering simpler, crossed out means deleted)
<img width="1153" height="215" alt="fields" src="https://github.com/user-attachments/assets/152ca962-643c-4668-b0b8-11a3741b8a01" />

## Issues Addressed

Closes #275 

## Additional Notes

In a coming follow up task, this data will be implemented into the tasteCards (task #276)
